### PR TITLE
Don't crash double-clicking whitespace in BP selection list

### DIFF
--- a/frmMain.vb
+++ b/frmMain.vb
@@ -25909,6 +25909,9 @@ Leave:
     End Sub
 
     Private Sub lstBPList_DoubleClick(sender As Object, e As EventArgs) Handles lstBPList.DoubleClick
+        If (lstBPList.SelectedItem Is Nothing) Then
+            Return
+        End If
         txtBPName.Text = lstBPList.SelectedItem.ToString()
         SelectBlueprint()
         lstBPList.Visible = False


### PR DESCRIPTION
When running from a self-compiled IPH, I found it crashing in the BP
selection list if I missed the target. This fixes it.

Test-Information:
Compiled and tried double-clicking whitespace around the list items,
without throwing the previously seen exception.