### PR TITLE
Fix API links in various dialogue boxes

### DIFF
--- a/Globals.vb
+++ b/Globals.vb
@@ -532,8 +532,8 @@ Public Module Public_Variables
         Dim BrokerRelations As Integer = SelectedCharacter.Skills.GetSkillLevel(3446)
 
         Dim TempFee As Double
-        ' Old BrokerFee % = (1.000 % – 0.050 % × BrokerRelationsSkillLevel) / e ^ (0.1000 × FactionStanding + 0.04000 × CorporationStanding)
-        ' BrokerFee % = (1.000 % – 0.050 % × BrokerRelationsSkillLevel) / 2 ^ (0.1400 × FactionStanding + 0.06000 × CorporationStanding) 
+        ' Old BrokerFeeÂ % = (1.000Â % Â– 0.050Â % Ã— BrokerRelationsSkillLevel) / e ^ (0.1000 Ã— FactionStanding + 0.04000 Ã— CorporationStanding)
+        ' BrokerFee % = (1.000 % Â– 0.050 % Ã— BrokerRelationsSkillLevel) / 2 ^ (0.1400 Ã— FactionStanding + 0.06000 Ã— CorporationStanding) 
         'TempFee = ((1 - 0.05 * BrokerRelations) / Math.Exp(0.1 * UserApplicationSettings.BrokerFactionStanding + 0.04 * UserApplicationSettings.BrokerCorpStanding)) / 100 * ItemMarketCost
         'TempFee = ((1 - 0.05 * BrokerRelations) / (2 ^ (0.14 * UserApplicationSettings.BrokerFactionStanding + 0.06 * UserApplicationSettings.BrokerCorpStanding))) / 100 * ItemMarketCost
 
@@ -4109,7 +4109,7 @@ InvalidDate:
             End If
 
             If ErrorText <> "" Then
-                fAccessError.ErrorLink = "http://support.eveonline.com/api/Key/CreatePredefined/589962/"
+                fAccessError.ErrorLink = "https://community.eveonline.com/support/api-key/CreatePredefined?accessMask=589962"
                 fAccessError.ShowDialog()
             End If
 

--- a/frmIndustryJobsViewer.vb
+++ b/frmIndustryJobsViewer.vb
@@ -81,7 +81,7 @@ Public Class frmIndustryJobsViewer
         '        Environment.NewLine & Environment.NewLine & "Please ensure your Customizable API includes 'IndustryJobs' under the 'Science & Industry' section to include industry jobs and then reload the API."
         '    fAccessError.Text = "API: No Industry Jobs Loaded"
 
-        '    fAccessError.ErrorLink = "http://community.eveonline.com/support/api-key/CreatePredefined?accessMask=589962/"
+        '    fAccessError.ErrorLink = "https://community.eveonline.com/support/api-key/CreatePredefined?accessMask=589962"
         '    fAccessError.ShowDialog()
 
         '    gbInventionJobs.Enabled = False

--- a/frmInventionMonitor.vb
+++ b/frmInventionMonitor.vb
@@ -51,7 +51,7 @@ Public Class frmInventionMonitor
                 Environment.NewLine & Environment.NewLine & "Please ensure your Customizable API includes 'IndustryJobs' under the 'Science & Industry' section to include industry jobs and then reload the API."
             fAccessError.Text = "API: No Industry Jobs Loaded"
 
-            fAccessError.ErrorLink = "http://support.eveonline.com/api/Key/CreatePredefined/589962/"
+            fAccessError.ErrorLink = "https://community.eveonline.com/support/api-key/CreatePredefined?accessMask=589962"
             fAccessError.ShowDialog()
 
             gbInventionMonitor.Enabled = False

--- a/frmLoadCharacterAPI.vb
+++ b/frmLoadCharacterAPI.vb
@@ -366,7 +366,7 @@ Public Class frmLoadCharacterAPI
     End Sub
 
     Private Sub linklabelPredefined_LinkClicked(sender As System.Object, e As System.Windows.Forms.LinkLabelLinkClickedEventArgs) Handles linklabelPredefined.LinkClicked
-        System.Diagnostics.Process.Start("http://community.eveonline.com/support/api-key/CreatePredefined?accessMask=589962/")
+        System.Diagnostics.Process.Start("https://community.eveonline.com/support/api-key/CreatePredefined?accessMask=589962")
     End Sub
 
 End Class

--- a/frmResearchAgents.vb
+++ b/frmResearchAgents.vb
@@ -106,7 +106,7 @@ Public Class frmResearchAgents
             fAccessError.ErrorText = "This API did not allow research agents to be loaded for associated characters." & _
                 Environment.NewLine & Environment.NewLine & "Please ensure your Customizable API includes 'Research' under the 'Science & Industry' section to include research agents and then reload the API."
             fAccessError.Text = "API: No Research Agents Loaded"
-            fAccessError.ErrorLink = "http://support.eveonline.com/api/Key/CreatePredefined/589962/"
+            fAccessError.ErrorLink = "https://community.eveonline.com/support/api-key/CreatePredefined?accessMask=589962"
             fAccessError.ShowDialog()
             ' Disable the refresh button
             btnRefresh.Enabled = False


### PR DESCRIPTION
Several of the links have an outdated target, and the others have an extra slash at the end that breaks the link.

I only edited the five lines with the links in them, apparently there is some inter-platform compatibility stuff which is resulting in other lines showing up as edited.