### PR TITLE
Fixed the "requested scopes don't exist" error

### DIFF
--- a/ESI.vb
+++ b/ESI.vb
@@ -88,7 +88,7 @@ Public Class ESI
         With ApplicationSettings
             ClientID = .ClientID
             SecretKey = .SecretKey
-            ScopesString = .Scopes
+            ScopesString = String.Join(" ", .Scopes.Split(New String() {" ", ",", vbCr, vbLf}, StringSplitOptions.RemoveEmptyEntries))
         End With
 
         AuthStreamText = ""


### PR DESCRIPTION
Issue #105 

The scopes as submitted to the web service must be space-delimited, but the file can store them in multiple formats, including CrLf or comma separated. Splitting and re-joining the scopes with spaces explicitly resolves the registration problem.